### PR TITLE
fix: missing head file

### DIFF
--- a/components/drivers/spi/spi_flash.h
+++ b/components/drivers/spi/spi_flash.h
@@ -26,6 +26,7 @@ struct spi_flash_device
 typedef struct spi_flash_device *rt_spi_flash_device_t;
 
 #ifdef RT_USING_MTD_NOR
+#include <drivers/mtd_nor.h>
 struct spi_flash_mtd
 {
     struct rt_mtd_nor_device            mtd_device;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
解决的问题: 当开启 `RT_USING_MTD_NOR` 宏时, 因缺少 `struct rt_mtd_nor_device` 声明相关的头文件而导致编译失败.  
解决方案: 添加相关头文件.  
已在 STM32F407 开发板上进行了测试验证.  
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
